### PR TITLE
Added Tor support

### DIFF
--- a/modules/gateways/btcpay.php
+++ b/modules/gateways/btcpay.php
@@ -54,6 +54,10 @@ function btcpay_config()
             'FriendlyName' => 'URI to your BTCPay server',
             'Type' => 'text'
         ),
+        'btcpayUrlTor' => array(
+            'FriendlyName' => 'Tor URI to your BTCPay server',
+            'Type' => 'text'
+        ),
         'redirectURL' => array(
                 'FriendlyName' => 'Redirect URL after invoice',
                 'Type' => 'text',
@@ -96,12 +100,22 @@ function btcpay_link($params)
     $country   = $params['clientdetails']['country'];
     $phone     = $params['clientdetails']['phonenumber'];
 
+    // Tor support
+    $parsedurl = parse_url($params['systemurl']);
+    $is_tor_enabled = preg_match("/\.onion$/", $_SERVER['HTTP_HOST']) && $params['btcpayUrlTor'] != '';
+    if (is_array($parsedurl) && $is_tor_enabled) {
+	$systemtor = "http://{$_SERVER['HTTP_HOST']}" . $parsedurl['path'];
+    } else {
+        $systemtor = "";
+    }
+
     // System Variables
-    $systemurl = $params['systemurl'];
+    $systemurl = $systemtor != '' ? $systemtor : $params['systemurl'];
 
     $post = array(
         'invoiceId'     => $invoiceid,
         'systemURL'     => $systemurl,
+        'ipnURL'        => $params['systemurl'] . '/modules/gateways/callback/btcpay.php',
         'buyerName'     => $firstname . ' ' . $lastname,
         'buyerAddress1' => $address1,
         'buyerAddress2' => $address2,

--- a/modules/gateways/btcpay/createinvoice.php
+++ b/modules/gateways/btcpay/createinvoice.php
@@ -110,8 +110,8 @@ $options['redirectURL'] = !empty($GATEWAY['redirectURL']) ? $GATEWAY['redirectUR
 $options['apiKey'] = $GATEWAY['apiKey'];
 $options['transactionSpeed'] = $GATEWAY['transactionSpeed'];
 $options['currency'] = $currency;
-$options['btcpayUrl'] = $GATEWAY['btcpayUrl'];
-$options['btcpayUrlTor'] = $GATEWAY['btcpayUrlTor'];
+$options['btcpayUrl'] = rtrim($GATEWAY['btcpayUrl'], "/") . "/";
+$options['btcpayUrlTor'] = rtrim($GATEWAY['btcpayUrlTor'], "/") . "/";
 
 $invoice = bpCreateInvoice($invoiceId, $price, $invoiceId, $options);
 

--- a/modules/gateways/btcpay/createinvoice.php
+++ b/modules/gateways/btcpay/createinvoice.php
@@ -105,12 +105,13 @@ unset($options['systemURL']);
 unset($options['redirectURL']);
 
 
-$options['notificationURL'] = $_POST['systemURL'] . '/modules/gateways/callback/btcpay.php';
+$options['notificationURL'] = $_POST['ipnURL'];
 $options['redirectURL'] = !empty($GATEWAY['redirectURL']) ? $GATEWAY['redirectURL'] : $_POST['systemURL'];
 $options['apiKey'] = $GATEWAY['apiKey'];
 $options['transactionSpeed'] = $GATEWAY['transactionSpeed'];
 $options['currency'] = $currency;
 $options['btcpayUrl'] = $GATEWAY['btcpayUrl'];
+$options['btcpayUrlTor'] = $GATEWAY['btcpayUrlTor'];
 
 $invoice = bpCreateInvoice($invoiceId, $price, $invoiceId, $options);
 
@@ -119,6 +120,10 @@ if (isset($invoice['error'])) {
     die('[ERROR] In modules/gateways/btcpay/createinvoice.php: Invoice error: ' . var_export($invoice['error'], true));
 } else {
     if (!empty($invoice['data']['url'])) {
+        $is_tor_enabled = preg_match("/\.onion$/", $_SERVER['HTTP_HOST']) && $options['btcpayUrlTor'] != '';
+        if ($is_tor_enabled) {
+            $invoice['data']['url'] = str_replace($options['btcpayUrl'], $options['btcpayUrlTor'], $invoice['data']['url']);
+        }
         header('Location: ' . $invoice['data']['url']);
     } else {
         $invError = "Something went wrong when creating the invoice and redirecting to BTCPay Server.";


### PR DESCRIPTION
This PR adds support for billing operating both via clearnet domain and .onion one. Previously, all communication between client and BTCPay Server was done via clearnet, which is fixed within this PR if appropriate support is enabled for BTCPay Server itself.